### PR TITLE
fix typos 04 用户模块-模型相关功能开发.md

### DIFF
--- a/04 用户模块-模型相关功能开发.md
+++ b/04 用户模块-模型相关功能开发.md
@@ -559,7 +559,7 @@ $ rails console
 
   ```ruby
   class UserTest < ActiveSupport::TestCase
-    # 使用合法的password
+    # 使用非法的password
     test 'invalid: user with invalid password' do
       user = User.new(email: 'test4@test.cn', password:'', role:1)
       assert_not user.valid?


### PR DESCRIPTION
注释错了，应为“非法的password”